### PR TITLE
Update Go Runtime (IE-32)

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -4,6 +4,6 @@ $env:GOARCH="amd64"
 
 # -tags lambda.norpc exludes the remote procedure call component of the lambda library
 # which reduces the binary size
-go build -tags lambda.norpc -o ./dist/main main.go
+go build -tags lambda.norpc -o ./dist/bootstrap main.go
 cd ./dist
-build-lambda-zip -output main.zip main
+build-lambda-zip -output main.zip bootstrap

--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,6 @@ GOARCH="arm64"
 # -tags lambda.norpc exludes the remote procedure call component of the lambda library
 # which reduces the binary size
 
-go build -tags lambda.norpc -o ./dist/main main.go
+go build -tags lambda.norpc -o ./dist/bootstrap main.go
 cd ./dist
-zip main.zip main
+zip bootstrap.zip bootstrap

--- a/iac/vars.tf
+++ b/iac/vars.tf
@@ -39,7 +39,7 @@ variable "api-resource" {
 }
 
 variable "runtime" {
-    default = "go1.x"
+    default = "provided.al2023"
     type    = string
 }
 


### PR DESCRIPTION
Motivation
---
AWS deprecated the go1.x runtime in favor of an updated runtime with faster startup and invocation time, so we need to make some changes to our build files.

Modifications
---
- Updated build files
- Updated runtime variable in tf