### PR TITLE
Provide Config (IE-44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ Deployments are handled automagically when your code is committed and merged wit
 
 This template project provides a file for defining your lambda function as a handler for a REST API endpoint in our system.
 
-TODO: Provide instructions on editing the `endpoint.yml` file.
+See the `ie2-config.yml` file for more information.

--- a/endpoint.yml
+++ b/endpoint.yml
@@ -1,5 +1,0 @@
-resource: my-resource
-  method: GET
-  req:
-  res:
-  

--- a/ie2-config.yml
+++ b/ie2-config.yml
@@ -1,0 +1,34 @@
+# the name of your lambda function
+# this value will be used to lookup up an existing lambda function
+name: lambda-poc
+# optional
+#   include the endpoint block IFF your function acts as a handler
+#   for a REST API endpoint
+endpoint:
+  # the version value allows for backward compatibility
+  # non-backward compatible changes should be placed in a new version
+  # this value will be used in the api path:
+  # ie. https://api.insightengine.com/v1
+  - version: 1
+    # the name of the REST API resource your function is responsible for
+    # this name will be included in the api as a path value
+    # ie. https://api.insightengine.com/v1/poc
+    resource: poc
+      # a list of REST methods (GET, POST, PUT, DELETE...) supported by your function
+      methods:
+        - name: GET
+          # declaration of the request object properties
+          req:
+          # declaration of the response object properties
+          res:
+  # This config allows for declaring multiple versions of your endpoint.
+  # New versions are typically required when adding new features that
+  #   are not backwards compatible. Changes to the shape of existing
+  #   json objects, parameter names, header names etc.
+  # The addition of new parameters does not typically require a new
+  #   version number unless the parameter is required or is deemed
+  #   necessary to avoid confusion for API consumers.
+  #- version: 2
+  #- version: 3
+
+  

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-# -tags lambda.norpc exludes the remote procedure call component of the lambda library
-# which reduces the binary size
+# -tags lambda.norpc
+#   reduces binary size by excluding the remote procedure call component
+# -ldflags="-s -w"
+#   reduces binary size by removing debug libraries
+env GOOS="linux" CGO_ENABLED="0" GOARCH="arm64" GOTOOLCHAIN="local" \
+    go build \
+    -tags lambda.norpc \
+    -ldflags="-s -w" \
+    -o ./dist/bootstrap main.go
 
-# -ldflags="-s -w" removes debug libraries from the binary, making it smaller
-env GOOS="linux" CGO_ENABLED="0" GOARCH="arm64" GOTOOLCHAIN="local" go build -tags lambda.norpc -ldflags="-s -w" -o ./dist/bootstrap main.go
+# copy the config
+cp ie2-config.yml ./dist/ie2-config.yml
+
 cd ./dist
 chmod +x bootstrap
 zip bootstrap.zip bootstrap


### PR DESCRIPTION
Motivation
---
We want to provide developers with a declarative format for their lambda function. This file will be used by our deployment pipeline to determine where to deploy the function and associate the lambda with a REST API endpoint.

The deployment is handled for the developer.

Modifications
---
- Added ie2-config.yml
- Included config file with build artifacts